### PR TITLE
Fix edge case where email is overriden

### DIFF
--- a/services/rule_engine/src/main/java/agents/Smith.java
+++ b/services/rule_engine/src/main/java/agents/Smith.java
@@ -6,8 +6,6 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 
-import com.mindsmiths.armory.event.UserConnected;
-import com.mindsmiths.armory.event.UserDisconnected;
 import com.mindsmiths.gsheetsAdapter.GSheetsAdapterAPI;
 import com.mindsmiths.gsheetsAdapter.reply.Spreadsheet;
 import com.mindsmiths.ruleEngine.model.Agent;
@@ -99,6 +97,7 @@ public class Smith extends Agent {
         List<String> data = List.of(mail);
         List<List<String>> values = List.of(data);
         GSheetsAdapterAPI.updateSheet(values, range);
+        nextEmailRow++;
     }
 
     public void addReviewToSheet(String mail, String gender, Integer age, Integer rating, String feedback, Long timestamp) {
@@ -106,5 +105,6 @@ public class Smith extends Agent {
         List<String> data = List.of(mail, gender, String.valueOf(age), String.valueOf(rating), feedback, String.valueOf(timestamp));
         List<List<String>> values = List.of(data);
         GSheetsAdapterAPI.updateSheet(values, range);
+        nextAnsRow++;
     }
 }


### PR DESCRIPTION
If multiple users submit their email on onboarding (so multiple requests before a  new heartbeat), Smith's current code will override the email until its row counter gets fixed by reading the spreadsheet (which happens every heartbeat). It should be safe to assume Smith's addReviewToSheet is safe from concurrency and this code allows Smith to temporarily increase the counter by one on each review/email entry. In case it gets it wrong (which should only happen if someone else was manipulating the sheet externally), it will be fixed by next heartbeat.